### PR TITLE
Gijs dev

### DIFF
--- a/src/main/resources/static/app/admin/lab/AdminLabController.js
+++ b/src/main/resources/static/app/admin/lab/AdminLabController.js
@@ -100,10 +100,26 @@ angular.module('ProcessApp.controllers')
                 });
             };
 
+            $scope.cancelByEscKey = function (key) {
+                if (key.keyCode === 27) {
+                    $scope.cancel();
+                }
+            };
+
+            $scope.cancel = function() {
+                $scope.editLabModal.hide();
+                $scope.editLabModal.destroy();
+            };
+
             $scope.edit = function(lb) {
                 $scope.editlab = lb;
                 $scope.editlab.emailAddressData = [].concat($scope.editlab.emailAddresses);
-                $scope.editLabModal = $modal({scope: $scope, templateUrl: '/app/admin/lab/editlab.html'});
+                $scope.editLabModal = $modal({
+                    id: 'editLabWindow',
+                    scope: $scope,
+                    templateUrl: '/app/admin/lab/editlab.html',
+                    backdrop: 'static'
+                });
             };
         }]);
 })(angular);

--- a/src/main/resources/static/app/admin/lab/editlab.html
+++ b/src/main/resources/static/app/admin/lab/editlab.html
@@ -3,7 +3,8 @@ Copyright (C) 2016  Stichting PALGA
 This file is distributed under the GNU Affero General Public License
 (see accompanying file LICENSE).
 -->
-<div class="modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal" tabindex="-1" role="dialog" aria-hidden="true"
+    ng-keypress="cancelByEscKey($event);">
 <div class="modal-dialog">
 <div class="modal-content">
 <form class="form-horizontal" role="form" name="labEditForm" ng-submit="update(editlab)" novalidate>
@@ -93,7 +94,7 @@ This file is distributed under the GNU Affero General Public License
 
 </div>
 <div class="modal-footer">
-    <a class="btn btn-default pull-left" ng-click="$destroy()">{{'Cancel'|translate}}</a>
+    <a class="btn btn-default pull-left" ng-click="cancel()">{{'Cancel'|translate}}</a>
     <button class="btn btn-info" type="submit" ng-disabled="labEditForm.$invalid || dataLoading">{{'Save'|translate}}</button>
 </div>
 </form>

--- a/src/main/resources/static/app/admin/user/AdminUserController.js
+++ b/src/main/resources/static/app/admin/user/AdminUserController.js
@@ -117,6 +117,17 @@ angular.module('ProcessApp.controllers')
                 $scope.edit(new User({'currentRole': 'requester'}));
             };
 
+            $scope.cancelByEscKey = function (key) {
+                if (key.keyCode === 27) {
+                    $scope.cancel();
+                }
+            };
+
+            $scope.cancel = function() {
+                $scope.editUserModal.hide();
+                $scope.editUserModal.destroy();
+            };
+
             $scope.edit = function(usr) {
                 $scope.edituser = usr;
                 $scope.hubLabs = _.map($scope.labs, function (lab) { lab.disabled = !lab.active; return lab; });
@@ -124,7 +135,12 @@ angular.module('ProcessApp.controllers')
                     lab.ticked = _.includes($scope.edituser.hubLabIds, lab.id);
                     return lab;
                 });
-                $scope.editUserModal = $modal({scope: $scope, templateUrl: '/app/admin/user/edituser.html', animation:false});
+                $scope.editUserModal = $modal({
+                    id: 'editUserWindow',
+                    scope: $scope,
+                    templateUrl: '/app/admin/user/edituser.html',
+                    backdrop: 'static'
+                });
             };
 
         }

--- a/src/main/resources/static/app/admin/user/edituser.html
+++ b/src/main/resources/static/app/admin/user/edituser.html
@@ -3,7 +3,8 @@ Copyright (C) 2016  Stichting PALGA
 This file is distributed under the GNU Affero General Public License
 (see accompanying file LICENSE).
 -->
-<div class="modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal" tabindex="-1" role="dialog" aria-hidden="true"
+    ng-keypress="cancelByEscKey($event);">
     <div class="modal-dialog">
         <div class="modal-content">
             <form class="form-horizontal" role="form" name="registrationForm" ng-submit="update(edituser)" novalidate>
@@ -176,7 +177,7 @@ This file is distributed under the GNU Affero General Public License
                     <br>
                 </div>
                 <div class="modal-footer">
-                    <a class="btn btn-default pull-left" ng-click="$hide()">{{'Cancel'|translate}}</a>
+                    <a class="btn btn-default pull-left" ng-click="cancel()">{{'Cancel'|translate}}</a>
                     <button class="btn btn-primary" type="submit"
                             ng-disabled="registrationForm.$invalid || dataLoading">{{'Save'|translate}}
                     </button>

--- a/src/main/resources/static/app/interceptors/ResponseInterceptor.js
+++ b/src/main/resources/static/app/interceptors/ResponseInterceptor.js
@@ -21,9 +21,7 @@ angular.module('ProcessApp.interceptors')
 
         return {
             'responseError': function(response) {
-                console.log('Location: ' + $location.path());
                 var url = _.get(response, 'config.url', '').trim();
-                console.log('url: ' + url);
 
                 switch(response.status) {
                 case 302:

--- a/src/main/resources/static/app/lab-request/LabRequestController.js
+++ b/src/main/resources/static/app/lab-request/LabRequestController.js
@@ -262,7 +262,7 @@ angular.module('ProcessApp.controllers')
             $scope.accept = function (labRequest) {
                 bootbox.confirm('Accept this lab request?' , function (result) {
                     if (result) {
-                        labRequest.customPUT({}, 'accept').then(function () {
+                        labRequest.customPUT(labRequest, 'accept').then(function () {
                             if ($scope.labReqModal) {
                                 $scope.labReqModal.hide();
                             }


### PR DESCRIPTION
- Fix admin modals for labs and users. Somehow the tags-input and modals don't like each other. Modals with tags-inputs need do be destroyed before loading a modal with the same template again (otherwise there are tag items in there without access to a tagsinputcontroller).
- Cleanup logging of response interceptor.
- Fix 'hub assistance' checkbox on accepting lab requests. (fixes https://jira.thehyve.nl/browse/DNTP-357)