### PR TITLE
Errors now get propagated correctly + improved error message

### DIFF
--- a/src/main/java/business/security/CustomAuthenticationProvider.java
+++ b/src/main/java/business/security/CustomAuthenticationProvider.java
@@ -116,7 +116,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
             super(message);
         }
         public UserAccountBlocked() {
-            super("User account blocked. Please retry in an hour.");
+            super("User account blocked because of too many failed login attempts. Please retry in an hour.");
         }
     }
 }

--- a/src/main/resources/static/app/interceptors/ResponseInterceptor.js
+++ b/src/main/resources/static/app/interceptors/ResponseInterceptor.js
@@ -76,7 +76,7 @@ angular.module('ProcessApp.interceptors')
                     });
                     return $q.reject(response);
                 default:
-                    return response;
+                    return $q.reject(response);
                 }
             }
         };

--- a/src/main/resources/static/app/services/LoginService.js
+++ b/src/main/resources/static/app/services/LoginService.js
@@ -62,9 +62,9 @@
                             $rootScope.authenticated = false;
                             deferred.reject();
                         }
-                    }).error(function() {
+                    }).error(function(response) {
                         $rootScope.authenticated = false;
-                        deferred.reject();
+                        deferred.reject(response);
                     });
                     return deferred.promise;
                 };
@@ -75,6 +75,9 @@
 
                 var _error = function(response) {
                     var message = _.get(response, 'data.message', '');
+                    if(message == ''){
+                        message = _.get(response, 'message', '');
+                    }
                     $rootScope.error = true;
                     $rootScope.authenticated = false;
                     $rootScope.errormessage = message;
@@ -89,19 +92,23 @@
                                 'content-type' : 'application/x-www-form-urlencoded'
                             }
                         }).success(function() {
-                            authenticate().then(function() {
-                                if ($rootScope.authenticated) {
-                                    $rootScope.error = false;
-                                    $rootScope.errormessage = '';
-                                    deferred.resolve();
-                                } else {
-                                    _error();
+                            authenticate().then(
+                                //Success
+                                function() {
+                                    if ($rootScope.authenticated) {
+                                        $rootScope.error = false;
+                                        $rootScope.errormessage = '';
+                                        deferred.resolve();
+                                    } else {
+                                        _error();
+                                        deferred.reject();
+                                    }
+                                },
+                                // Error
+                                function(response) {
+                                    _error(response);
                                     deferred.reject();
-                                }
-                            }, function() {
-                                _error();
-                                deferred.reject();
-                            });
+                                });
                         }).error(function(response) {
                             _error(response);
                             deferred.reject(response);

--- a/src/main/resources/static/messages/messages_nl.js
+++ b/src/main/resources/static/messages/messages_nl.js
@@ -269,7 +269,6 @@
         'Forgot password': 'Wachtwoord vergeten',
         'Create an account': 'Een account maken',
         'Bad credentials': 'Ongeldige logingegevens.',
-        'User account blocked. Please retry in 15 minutes.': 'Account geblokkeerd. Probeert u het opnieuw over 15 minuten.',
         'User account blocked because of too many failed login attempts. Please retry in an hour.': 'Account geblokeerd vanwege te veel verkeerde inlogpogingen. Probeer het aub over een uur opnieuw.',
         'Email address (lower case)': 'E-mailadres (kleine letters)',
 

--- a/src/main/resources/static/messages/messages_nl.js
+++ b/src/main/resources/static/messages/messages_nl.js
@@ -270,6 +270,7 @@
         'Create an account': 'Een account maken',
         'Bad credentials': 'Ongeldige logingegevens.',
         'User account blocked. Please retry in 15 minutes.': 'Account geblokkeerd. Probeert u het opnieuw over 15 minuten.',
+        'User account blocked because of too many failed login attempts. Please retry in an hour.': 'Account geblokeerd vanwege te veel verkeerde inlogpogingen. Probeer het aub over een uur opnieuw.',
         'Email address (lower case)': 'E-mailadres (kleine letters)',
 
         /* ========= */


### PR DESCRIPTION
ResponseInterceptor.js wasn't passing along errors that weren't specifically mentioned, so errors were handled by success handlers rather than error handlers (like 401 statuses), causing error message to not be handed to the front end correctly. 

See: http://stackoverflow.com/questions/38100992/http-request-response-comes-to-success-function-even-when-status-code-is-401