### PR TITLE
Dntp 577 572 fixing $digest

### DIFF
--- a/e2e/scenario_complete_happy_request.feature
+++ b/e2e/scenario_complete_happy_request.feature
@@ -49,7 +49,7 @@ Feature: scenario request Request for excerpts + PA reports + materials
     materialsRequest
     linkageWithPersonalDataYes
     informedConsentNo
-    germlinemutationYes
+    germlineMutationYes
     """
     And I fill the form with the following data
     """

--- a/e2e/scenario_hub_user.feature
+++ b/e2e/scenario_hub_user.feature
@@ -150,6 +150,7 @@ Feature: scenario request Request for excerpts + PA reports + materials + clinic
     And I click on the 'Actions' button
     And I click on the 'Approve' button
     And I click on the 'OK' button
+    And I click on the object with id 'hub-modal-save-button'
     Then the current request should have 'Approved' status
     Then the page should contain the text 'PA reports have NOT been sent to the requester.'
 

--- a/src/main/resources/static/app/lab-request/edit-hub-assistance.html
+++ b/src/main/resources/static/app/lab-request/edit-hub-assistance.html
@@ -47,7 +47,7 @@
             <a class="btn btn-default" ng-click="cancelHubAssistance();">{{'Cancel'|translate}}</a>
         </span>
         <span class="pull-right">
-            <button class="btn btn-default btn-primary"
+            <button class="btn btn-default btn-primary" id="hub-modal-save-button"
                 ng-click="update(hubAssistanceRequest);">{{'Save'|translate}}</button>
         </span>
       </div>

--- a/src/main/resources/static/app/processapp.js
+++ b/src/main/resources/static/app/processapp.js
@@ -312,8 +312,17 @@
                   }
                 });
 
+                $rootScope.timeCache = 0;
+
                 $rootScope.getDatetime = function() {
-                    return Date.now();
+                    var now = Date.now();
+                    var diff = Math.abs(now - $rootScope.timeCache);
+                    if (diff > 100){
+                        $rootScope.timeCache = now;
+                        return now;
+                    } else {
+                        return $rootScope.timeCache;
+                    }
                 };
             }])
         .filter("statusTextFilter", function ($filter) {


### PR DESCRIPTION
Some small updates to the e2e tests, but most importantly fixing "10 $digest() iterations reached" errors that were blocking selenium from communicating with angular. 

Error was caused by the getDatetime() function returning the current timestamp (and constantly returning a different value, freaking out angular) so now the time value is cached for 100ms and the value from the cache (if set) is returned instead of the actual current time.