### PR TITLE
Fix the error endpoint, used for rendering errors as JSON.

### DIFF
--- a/src/main/java/business/controllers/CustomErrorController.java
+++ b/src/main/java/business/controllers/CustomErrorController.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @RestController
 public class CustomErrorController implements ErrorController {
 
-    private static final String PATH = "/api/error";
+    private static final String PATH = "/error";
 
     @Autowired
     ErrorAttributes errorAttributes;

--- a/src/main/java/business/security/HttpSecurityConfiguration.java
+++ b/src/main/java/business/security/HttpSecurityConfiguration.java
@@ -79,7 +79,8 @@ public class HttpSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     "/*.ico",
                     "/api/public/**",
                     "/api/password/request-new",
-                    "/api/password/reset"
+                    "/api/password/reset",
+                    "/error"
                 ).permitAll()
                 .antMatchers(HttpMethod.POST, "/api/register/users").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/register/users/**").permitAll()


### PR DESCRIPTION
Previously every error would result in `404` because the error page could not be found.