### PR TITLE
Update dates in the footer

### DIFF
--- a/src/main/webapp/app/components/footer/footer.html
+++ b/src/main/webapp/app/components/footer/footer.html
@@ -7,7 +7,7 @@ This file is distributed under the GNU Affero General Public License
     <p class="text-center footer-text">
         {{'DNTP &mdash; Dutch National Tissuebank Portal'|translate}}
         &nbsp; | &nbsp;
-        &copy; 2017&ndash;2019
+        &copy; 2017&ndash;2021
         <a href="http://www.palga.nl/" target="_blank">Stichting PALGA</a>
         &nbsp; | &nbsp;
         <a href="https://github.com/thehyve/dntp-portal" target="_blank">{{'Source'|translate}}</a>


### PR DESCRIPTION
For the sake of consistency - the footer has a starting year 2017, whereas the license in README and copyrights in the code have 2016, should the footer be changed to 2016-2021? @gijskant